### PR TITLE
Update OrderController.js

### DIFF
--- a/27-binding-models-forms/content/js/OrderController.js
+++ b/27-binding-models-forms/content/js/OrderController.js
@@ -3,10 +3,7 @@ function OrderController() {
     name: '',
     email: '',
     location: '',
-    product: {
-      label: '',
-      id: ''
-    },
+    product: '',
     comments: ''
   };
   this.submitOrder = function () {


### PR DESCRIPTION
In order for "required" validation to work on the select field, "product" must initialize with an empty value instead of an object containing "label" and "id" with empty values. If not, the validation only works when an option is selected and then selection reverted to the default option. Not sure if this is the case across all platforms & browsers - happens in my case in both Chrome & Firefox on Debian Stretch.
